### PR TITLE
fix local history access for tournament predictor

### DIFF
--- a/C621/Branch_Predictor/Branch_Predictor.c
+++ b/C621/Branch_Predictor/Branch_Predictor.c
@@ -219,8 +219,8 @@ bool predict(Branch_Predictor *branch_predictor, Instruction *instr)
 
     // Step six, update global history register
     branch_predictor->global_history = branch_predictor->global_history << 1 | instr->taken;
-    local_history_table[local_history_table_index] =
-            local_history_table[local_history_table_index] << 1 | instr->taken;
+    branch_predictor->local_history_table[local_history_table_idx] =
+            branch_predictor->local_history_table[local_history_table_idx] << 1 | instr->taken;
     // exit(0);
     //
     return prediction_correct;


### PR DESCRIPTION
The recent fix does not compile when `TOURNAMENT` is not defined in Branch_Predictor.h. This PR allows both predictor configurations to compile.